### PR TITLE
Produce datomic assertions from salesforce queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.1
+
+* Introduce sails-forth.datomic ns with assert-query fn
+
 ## 0.8.0
 
 * Update to clojure-1.9.0, also drop boot-mvn

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ version detection.
 
 ## Installation
 
-`sparkfund/sails-forth 0.8.0`
+`sparkfund/sails-forth 0.8.1`
 
 ## Usage
 
@@ -58,6 +58,16 @@ straightforward.
 
 ``` clojure
 (def mc (sf/build-memory-client (sf/schema client #{:contact})))
+```
+
+There is support for building transactions which can be applied to datomic
+to record observations from salesforce queries:
+
+``` clojure
+(require '[sails-forth.datomic :as sd])
+
+(def txns
+  (sd/assert-query client "sf" {:find [:opportunity :id :name [:customer :id :name]]}))
 ```
 
 ## Configuration

--- a/build.boot
+++ b/build.boot
@@ -15,6 +15,7 @@
    [cheshire "5.5.0"]
    [clj-http "2.0.0"]
    [clj-time "0.11.0"]
+   [com.datomic/datomic-free "0.9.5561.62" :scope "test"]
    [com.github.jsqlparser/jsqlparser "0.9.5"]
    [org.clojure/clojure "1.9.0" :scope "provided"]
    [org.clojure/test.check "0.9.0" :scope "test"]

--- a/build.boot
+++ b/build.boot
@@ -1,4 +1,4 @@
-(def version "0.8.1-SNAPSHOT")
+(def version "0.8.1")
 
 (task-options!
   pom {:project 'sparkfund/sails-forth

--- a/build.boot
+++ b/build.boot
@@ -1,4 +1,4 @@
-(def version "0.8.0")
+(def version "0.8.1-SNAPSHOT")
 
 (task-options!
   pom {:project 'sparkfund/sails-forth

--- a/src/sails_forth/datomic.clj
+++ b/src/sails_forth/datomic.clj
@@ -155,16 +155,6 @@
                               stateCode (assoc (attr "state-code") stateCode)
                               postalCode (assoc (attr "postal-code") postalCode)
                               countryCode (assoc (attr "country-code") countryCode))])
-                         "currency"
-                         (try
-                           [(.setScale value 2 BigDecimal/ROUND_UP)]
-                           (catch ArithmeticException e
-                             (throw (ex-info "Could not set currency to pennies"
-                                             {:value value
-                                              :field field-key
-                                              :object-type object-key
-                                              :object m}
-                                             e))))
                          [value])]
                    (-> txn
                        (assoc attr value)
@@ -178,7 +168,7 @@
    the results of the given query in a datomic database.
 
    Given an ns-prefix of `ex` and a query of
-   `{:find [:customer :id :sectors [:contact :id :phone]]}`
+   `{:find [:customer :id :sectors [:contact :id :phone]]}`:
 
    The first transaction asserts a set of attributes that will be defined on the
    attributes that will model the salesforce fields where there is no direct

--- a/src/sails_forth/datomic.clj
+++ b/src/sails_forth/datomic.clj
@@ -1,0 +1,95 @@
+(ns sails-forth.datomic
+  (:require [sails-forth.client :as c]))
+
+(def datomic-types
+  {"datetime" :db.type/instant
+   "date" :db.type/instant
+   "int" :db.type/long
+   "percent" :db.type/bigdec
+   "double" :db.type/bigdec
+   "currency" :db.type/bigdec
+   "id" :db.type/string
+   "string" :db.type/string
+   "reference" :db.type/ref
+   "boolean" :db.type/boolean
+   "textarea" :db.type/string
+   ;; TODO enum? But how can it be constrained?
+   "picklist" :db.type/string
+   "url" :db.type/uri
+   ;; TODO enum? Same as picklist but with cardinality many
+   "multipicklist" :db.type/string
+   ;; TODO component? Does this have discrete pieces?
+   "address" :db.type/string
+   ;; TODO component? Same as address
+   "phone" :db.type/string})
+
+(defn datomic-schema
+  [client ns-prefix type fields]
+  (let [ns-prefix (name ns-prefix)
+        ns (format "%s.%s" ns-prefix (name type))
+        name-md (keyword ns-prefix "name")
+        formula-md (keyword ns-prefix "formula")
+        helptext-md (keyword ns-prefix "helptext")
+        ;; TODO there is so much other salesforce schema metadata
+        md [{:db/ident name-md
+             :db/doc "Salesforce field name"
+             :db/valueType :db.type/string
+             :db/cardinality :db.cardinality/one}
+            {:db/ident formula-md
+             :db/doc "Salesforce field formula"
+             :db/valueType :db.type/string
+             :db.cardinality/one :db.cardinality/one}
+            {:db/ident helptext-md
+             :db/doc "Salesforce help text"
+             :db/valueType :db.type/string
+             :db.cardinality/one :db.cardinality/one}]]
+    (into md (map (fn [key field]
+                    (let [{:keys [name
+                                  label
+                                  type
+                                  calculatedFormula
+                                  inlineHelpText
+                                  unique]}
+                          field]
+                      (cond-> {:db/ident (keyword ns key)
+                               :db/doc label
+                               :db/valueType (get datomic-types type)
+                               :db/cardinality :db.cardinality/one
+                               name-md name}
+                        ;; Sorta funny that id types don't have :unique true
+                        (or (= "id" type) unique)
+                        (assoc :db/unique :db.unique/identity)
+                        calculatedFormula
+                        (assoc formula-md calculatedFormula)
+                        inlineHelpText
+                        (assoc helptext-md inlineHelpText)))))
+          (c/get-fields client type))))
+
+(comment
+  {:find [:contact :id :name [:phone :id :number]]}
+
+  (datomic-schema client :sparkfund.salesforce :contact [:id :name]) ; =>
+
+  [{:db/ident :sparkfund.salesforce.contact/id
+    :db/valueType :db.type/string
+    :db/doc "..."
+    :db.install/_attribute :db.part/db
+    ;; :db.unique :db.unique/value ;; :db.unique/identity
+    ;; :db.index true
+    ;; :db.component
+    }
+   {:db/ident :sparkfund.salesforce.contact/name
+    :db/valueType :db.type/string
+    :db/doc "..."
+    :db.install/_attribute :db.part/db}
+   ]
+
+  (datomic-schema client :sparkfund.salesforce :phone [:id :name])
+
+  [{:db/id "contact"
+    :contact/id ...
+    :contact/name ...
+    :contact/phone {:phone/id ...
+                    :phone/number ...}}]
+
+  )

--- a/src/sails_forth/datomic.clj
+++ b/src/sails_forth/datomic.clj
@@ -1,5 +1,8 @@
 (ns sails-forth.datomic
-  (:require [sails-forth.client :as c]))
+  (:require [clj-time.coerce :as tc]
+            [clojure.string :as s]
+            [sails-forth.client :as c]
+            [sails-forth.query :as q]))
 
 (def datomic-types
   {"datetime" :db.type/instant
@@ -13,83 +16,141 @@
    "reference" :db.type/ref
    "boolean" :db.type/boolean
    "textarea" :db.type/string
-   ;; TODO enum? But how can it be constrained?
-   "picklist" :db.type/string
+   "picklist" :db.type/ref
    "url" :db.type/uri
-   ;; TODO enum? Same as picklist but with cardinality many
-   "multipicklist" :db.type/string
+   "multipicklist" :db.type/ref
    ;; TODO component? Does this have discrete pieces?
-   "address" :db.type/string
+   ;; "address" :db.type/string
    ;; TODO component? Same as address
-   "phone" :db.type/string})
+   ;; "phone" :db.type/string
+   })
 
-(defn datomic-schema
-  [client ns-prefix type fields]
+(defn metadata-schema
+  [ns-prefix]
+  ;; TODO there are so many other salesforce schema metadata
   (let [ns-prefix (name ns-prefix)
-        ns (format "%s.%s" ns-prefix (name type))
         name-md (keyword ns-prefix "name")
+        type-md (keyword ns-prefix "type")
         formula-md (keyword ns-prefix "formula")
         helptext-md (keyword ns-prefix "helptext")
-        ;; TODO there is so much other salesforce schema metadata
-        md [{:db/ident name-md
-             :db/doc "Salesforce field name"
-             :db/valueType :db.type/string
-             :db/cardinality :db.cardinality/one}
-            {:db/ident formula-md
-             :db/doc "Salesforce field formula"
-             :db/valueType :db.type/string
-             :db.cardinality/one :db.cardinality/one}
-            {:db/ident helptext-md
-             :db/doc "Salesforce help text"
-             :db/valueType :db.type/string
-             :db.cardinality/one :db.cardinality/one}]]
-    (into md (map (fn [key field]
-                    (let [{:keys [name
-                                  label
-                                  type
-                                  calculatedFormula
-                                  inlineHelpText
-                                  unique]}
-                          field]
-                      (cond-> {:db/ident (keyword ns key)
+        picklist-value-md (keyword ns-prefix "picklist-value")]
+    [{:db/ident name-md
+      :db/doc "Salesforce field name"
+      :db/valueType :db.type/string
+      :db/cardinality :db.cardinality/one}
+     {:db/ident type-md
+      :db/doc "Salesforce field type"
+      :db/valueType :db.type/string
+      :db/cardinality :db.cardinality/one}
+     {:db/ident formula-md
+      :db/doc "Salesforce field formula"
+      :db/valueType :db.type/string
+      :db/cardinality :db.cardinality/one}
+     {:db/ident helptext-md
+      :db/doc "Salesforce help text"
+      :db/valueType :db.type/string
+      :db/cardinality :db.cardinality/one}
+     {:db/ident picklist-value-md
+      :db/doc "Salesforce picklist value"
+      :db/valueType :db.type/string
+      :db/cardinality :db.cardinality/one}]))
+
+(defn object-schema
+  [ns-prefix type fields]
+  (let [ns-prefix (name ns-prefix)
+        ns (str ns-prefix "." (name type))]
+    (letfn [(enum-datoms [key field]
+              (letfn [(enum-datom [item]
+                        (let [ns (str ns "." (name key))
+                              {:keys [label value]} item]
+                          ;; TODO value may not become a keyword that can be
+                          ;; read by the clj/edn reader. That's annoying.
+                          ;; Whatever we choose to do here must be understood
+                          ;; by our readers and writers
+                          {:db/ident (keyword ns value)
+                           ;; TODO are docstrings allowed on non-attributes?
+                           :db/doc label
+                           (keyword ns-prefix "picklist-value") value}))]
+                (map enum-datom (:picklistValues field))))
+            (field-datoms [[key field]]
+              (let [{:keys [name
+                            label
+                            type
+                            calculatedFormula
+                            inlineHelpText
+                            unique]}
+                    field
+                    cardinality (if (= "multipicklist" type)
+                                  :db.cardinality/many
+                                  :db.cardinality/one)]
+                (cons (cond-> {:db/ident (keyword ns (clojure.core/name key))
                                :db/doc label
                                :db/valueType (get datomic-types type)
-                               :db/cardinality :db.cardinality/one
-                               name-md name}
+                               :db/cardinality cardinality
+                               (keyword ns-prefix "name") name
+                               (keyword ns-prefix "type") type}
                         ;; Sorta funny that id types don't have :unique true
                         (or (= "id" type) unique)
                         (assoc :db/unique :db.unique/identity)
                         calculatedFormula
-                        (assoc formula-md calculatedFormula)
+                        (assoc (keyword ns-prefix "formula") calculatedFormula)
                         inlineHelpText
-                        (assoc helptext-md inlineHelpText)))))
-          (c/get-fields client type))))
+                        (assoc (keyword ns-prefix "helptext") inlineHelpText))
+                      (when (case type
+                              "picklist" true
+                              "multipicklist" true
+                              false)
+                        (enum-datoms key field)))))]
+      (into [] (mapcat field-datoms) fields))))
+
+(defn build-schema!
+  [client ns-prefix types]
+  (into (metadata-schema ns-prefix)
+        (mapcat (fn [type]
+                  (object-schema ns-prefix type (c/get-fields client type))))
+        types))
+
+(defn assert-object
+  [ns-prefix type fields m]
+  (let [ns-prefix (name ns-prefix)
+        ns (str ns-prefix "." (name type))]
+    (reduce-kv (fn [txn field value]
+                 (let [attr (keyword ns (name field))
+                       type (get-in fields [field :type])
+                       value (case type
+                               ;; TODO coordinate with enum-datom
+                               "picklist"
+                               (keyword (str ns "." (name field)) value)
+                               "multipicklist"
+                               (mapv (partial keyword (str ns "." (name field)))
+                                     (s/split value #";"))
+                               "date"
+                               (tc/to-date value)
+                               "reference"
+                               ;; TODO here's the good bit do we just recurse?
+                               ;; If so we need the the reference's type and
+                               ;; fields
+                               nil
+                               value)]
+                   (assoc txn attr value)))
+               {}
+               m)))
+
+;; TODO the problem with doing this generally is that the name of an object's
+;; reference is not always the same as the type, as in multiple references to
+;; accounts from an opportunity under different names. Those data are available
+;; we just need to figure out how to get at them sensibly.
+;; TODO also do we want the whole schema for each type or just projections that
+;; permit out query results
+(defn assert-query!
+  [client ns-prefix query])
 
 (comment
-  {:find [:contact :id :name [:phone :id :number]]}
-
-  (datomic-schema client :sparkfund.salesforce :contact [:id :name]) ; =>
-
-  [{:db/ident :sparkfund.salesforce.contact/id
-    :db/valueType :db.type/string
-    :db/doc "..."
-    :db.install/_attribute :db.part/db
-    ;; :db.unique :db.unique/value ;; :db.unique/identity
-    ;; :db.index true
-    ;; :db.component
-    }
-   {:db/ident :sparkfund.salesforce.contact/name
-    :db/valueType :db.type/string
-    :db/doc "..."
-    :db.install/_attribute :db.part/db}
-   ]
-
-  (datomic-schema client :sparkfund.salesforce :phone [:id :name])
-
-  [{:db/id "contact"
-    :contact/id ...
-    :contact/name ...
-    :contact/phone {:phone/id ...
-                    :phone/number ...}}]
-
+  ;; TODO we could add metadata to the query results with the type of each query
+  ;; path, e.g.
+  ^{:path-types {[:opportunity] :opportunity
+                 [:opportunity :customer-account] :account}}
+  [{:opportunity [:customer-account {:name "Rey"}]}]
+  ;; This could also be the job of some local coordinator, but that ties a good
+  ;; bit of functionality to an impure fn
   )

--- a/src/sails_forth/datomic.clj
+++ b/src/sails_forth/datomic.clj
@@ -167,7 +167,8 @@
   "Returns a seq of transaction seqs that if transacted in order will assert
    the results of the given query in a datomic database.
 
-   Given an ns-prefix of `ex` and a query of `{:find [:customer :id :sectors]}`
+   Given an ns-prefix of `ex` and a query of
+   `{:find [:customer :id :sectors [:contact :id :phone]]}`
 
    The first transaction asserts a set of attributes that will be defined on the
    attributes that will model the salesforce fields where there is no direct
@@ -180,10 +181,17 @@
 
    The last transaction asserts the entities returned by the query.
 
-   Most field values have natural datomic types. Notably, however, picklist
-   and multipicklist fields are modeled as enums whose idents are a
-   keywordized version of the picklist value with a namespace derived from
-   the object and field, e.g. `ex.object.customer.sectors/energy-efficiency`."
+   Most field values have natural datomic types. Notable exceptions include:
+
+   * picklist, multipicklist: stored as strings. The api does not provide any
+     access to inactive picklist items, which makes asserting e.g. enum values
+     problematic
+   * recordtype references: stored as strings for similar reasons
+   * address: stored as component references
+
+   There are some modest restrictions on the queries that can be asserted.
+   All join references must include an identity field, except for recordtype
+   joins which must only include the `:name` field."
   [client ns-prefix query]
   (let [objects (into []
                       (comp (map (comp first seq))

--- a/src/sails_forth/datomic.clj
+++ b/src/sails_forth/datomic.clj
@@ -12,7 +12,6 @@
    "date" :db.type/instant
    "int" :db.type/long
    "percent" :db.type/bigdec
-   "double" :db.type/bigdec
    "currency" :db.type/bigdec
    "id" :db.type/string
    "string" :db.type/string
@@ -91,12 +90,19 @@
                   cardinality (if (= "multipicklist" type)
                                 :db.cardinality/many
                                 :db.cardinality/one)
-                  recordtype? (= key :recordtype)]
+                  recordtype? (= key :recordtype)
+                  valuetype (cond
+                              recordtype? :db.type/string
+                              (= "double" type)
+                              (case (clj/double-type field)
+                                :long :db.type/long
+                                :bigint :db.type/bigint
+                                :bigdec :db.type/bigdec)
+                              :else
+                              (get datomic-types type))]
               (cond-> {:db/ident (field-attr ns-prefix object-key key)
                        :db/doc label
-                       :db/valueType (if-not recordtype?
-                                       (get datomic-types type)
-                                       :db.type/string)
+                       :db/valueType valuetype
                        :db/cardinality cardinality
                        (field-ident ns-prefix "name") name
                        (field-ident ns-prefix "type") type}

--- a/src/sails_forth/datomic.clj
+++ b/src/sails_forth/datomic.clj
@@ -157,12 +157,14 @@
                               countryCode (assoc (attr "country-code") countryCode))])
                          "currency"
                          (try
-                           [(.setScale value 2)]
+                           [(.setScale value 2 BigDecimal/ROUND_UP)]
                            (catch ArithmeticException e
-                             (throw (ex-info e "Could not set currency to pennies"
+                             (throw (ex-info "Could not set currency to pennies"
                                              {:value value
                                               :field field-key
-                                              :object object-key}))))
+                                              :object-type object-key
+                                              :object m}
+                                             e))))
                          [value])]
                    (-> txn
                        (assoc attr value)

--- a/src/sails_forth/datomic.clj
+++ b/src/sails_forth/datomic.clj
@@ -63,22 +63,21 @@
     :db/valueType :db.type/string
     :db/cardinality :db.cardinality/one}])
 
-(def picklist-name
-  (let [allowed-punct (into #{} "*+!-_'?")]
-    (fn [picklist-value]
-      (let [sb (StringBuffer.)]
-        (doseq [c (seq picklist-value)]
-          (cond (and (zero? (.length sb))
-                     (Character/isDigit c))
-                nil
-                (or (Character/isLetterOrDigit c)
-                    (contains? allowed-punct c))
-                (.append sb (Character/toLowerCase c))
-                :else
-                (.append sb \-)))
-        (-> (.toString sb)
-            (s/replace #"-+" "-")
-            (s/replace #"^-|-$" ""))))))
+(defn picklist-name
+  [picklist-value]
+  (let [sb (StringBuffer.)]
+    (doseq [c (seq picklist-value)]
+      (cond (and (zero? (.length sb))
+                 (Character/isDigit c))
+            nil
+            (or (Character/isLetterOrDigit c)
+                (case c (\* \+ \! \- \_ \' \?) true false))
+            (.append sb (Character/toLowerCase c))
+            :else
+            (.append sb \-)))
+    (-> (.toString sb)
+        (s/replace #"-+" "-")
+        (s/replace #"^-|-$" ""))))
 
 (defn object-schema
   [ns-prefix object-key fields]

--- a/src/sails_forth/datomic.clj
+++ b/src/sails_forth/datomic.clj
@@ -142,7 +142,7 @@
                          "reference"
                          (if-not recordtype?
                            (let [ref-key (clj/field->refers-attr field)
-                                 ref-object (assert-object! client ns-prefix ref-key value)]
+                                 ref-object (assert-object client ns-prefix ref-key value)]
                              [(dissoc ref-object ::types)
                               (get ref-object ::types)])
                            [(get value :name)])
@@ -195,8 +195,8 @@
   [client ns-prefix query]
   (let [objects (into []
                       (comp (map (comp first seq))
-                            (map (partial apply assert-object! client ns-prefix)))
+                            (map (partial apply assert-object client ns-prefix)))
                       (q/query client query))
         object-keys (reduce set/union #{} (map ::types objects))]
-    (conj (build-schema! client ns-prefix object-keys)
+    (conj (build-schema client ns-prefix object-keys)
           (into [] (map (fn [m] (dissoc m ::types)) objects)))))

--- a/src/sails_forth/datomic.clj
+++ b/src/sails_forth/datomic.clj
@@ -167,16 +167,16 @@
   "Returns a seq of transaction seqs that if transacted in order will assert
    the results of the given query in a datomic database.
 
-   Given an ns-prefix of `ex` and a query of
+   Given an ns-prefix of `\"sf\"` and a query of
    `{:find [:customer :id :sectors [:contact :id :phone]]}`:
 
    The first transaction asserts a set of attributes that will be defined on the
    attributes that will model the salesforce fields where there is no direct
-   datomic analog, e.g. `ex.field/helptext`.
+   datomic analog, e.g. `sf.field/helptext`.
 
    The second transaction asserts a set of attributes that model the
    fields of objects used in the query,
-   e.g. `ex.object.customer/id`. Note this is a complete set of
+   e.g. `sf.object.customer/id`. Note this is a complete set of
    attributes, not limited simply to those used in the query.
 
    The last transaction asserts the entities returned by the query.

--- a/src/sails_forth/datomic.clj
+++ b/src/sails_forth/datomic.clj
@@ -155,6 +155,14 @@
                               stateCode (assoc (attr "state-code") stateCode)
                               postalCode (assoc (attr "postal-code") postalCode)
                               countryCode (assoc (attr "country-code") countryCode))])
+                         "currency"
+                         (try
+                           [(.setScale value 2)]
+                           (catch ArithmeticException e
+                             (throw (ex-info e "Could not set currency to pennies"
+                                             {:value value
+                                              :field field-key
+                                              :object object-key}))))
                          [value])]
                    (-> txn
                        (assoc attr value)

--- a/src/sails_forth/datomic.clj
+++ b/src/sails_forth/datomic.clj
@@ -1,4 +1,5 @@
 (ns sails-forth.datomic
+  "Provides fns to assert the results of salesforce queries as datoms."
   (:require [clj-time.coerce :as tc]
             [clojure.set :as set]
             [clojure.string :as s]
@@ -21,41 +22,63 @@
    "picklist" :db.type/ref
    "url" :db.type/uri
    "multipicklist" :db.type/ref
-   ;; TODO component? Does this have discrete pieces?
+   ;; maybe components? Do these have discrete pieces?
    ;; "address" :db.type/string
-   ;; TODO component? Same as address
    ;; "phone" :db.type/string
    })
 
+(defn field-ident
+  [ns-prefix field-name]
+  (keyword (str (name ns-prefix) ".field") (name field-name)))
+
+(defn field-attr
+  [ns-prefix object-name field-name]
+  (keyword (str (name ns-prefix) ".object." (name object-name)) (name field-name)))
+
+(defn enum-ident
+  [ns-prefix object-name field-name value]
+  (keyword (str (name ns-prefix) ".object." (name object-name) "." (name field-name)) (name value)))
+
 (defn metadata-schema
   [ns-prefix]
-  ;; TODO there are so many other salesforce schema metadata
-  (let [ns-prefix (name ns-prefix)
-        name-md (keyword ns-prefix "name")
-        type-md (keyword ns-prefix "type")
-        formula-md (keyword ns-prefix "formula")
-        helptext-md (keyword ns-prefix "helptext")
-        picklist-value-md (keyword ns-prefix "picklist-value")]
-    [{:db/ident name-md
-      :db/doc "Salesforce field name"
-      :db/valueType :db.type/string
-      :db/cardinality :db.cardinality/one}
-     {:db/ident type-md
-      :db/doc "Salesforce field type"
-      :db/valueType :db.type/string
-      :db/cardinality :db.cardinality/one}
-     {:db/ident formula-md
-      :db/doc "Salesforce field formula"
-      :db/valueType :db.type/string
-      :db/cardinality :db.cardinality/one}
-     {:db/ident helptext-md
-      :db/doc "Salesforce help text"
-      :db/valueType :db.type/string
-      :db/cardinality :db.cardinality/one}
-     {:db/ident picklist-value-md
-      :db/doc "Salesforce picklist value"
-      :db/valueType :db.type/string
-      :db/cardinality :db.cardinality/one}]))
+  ;; More field metadata could come along for the ride
+  [{:db/ident (field-ident ns-prefix "name")
+    :db/doc "Salesforce field name"
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}
+   {:db/ident (field-ident ns-prefix "type")
+    :db/doc "Salesforce field type"
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}
+   {:db/ident (field-ident ns-prefix "formula")
+    :db/doc "Salesforce field formula"
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}
+   {:db/ident (field-ident ns-prefix "helptext")
+    :db/doc "Salesforce field help text"
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}
+   {:db/ident (field-ident ns-prefix "picklist-value")
+    :db/doc "Salesforce field picklist value"
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one}])
+
+(def picklist-name
+  (let [allowed-punct (into #{} "*+!-_'?")]
+    (fn [picklist-value]
+      (let [sb (StringBuffer.)]
+        (doseq [c (seq picklist-value)]
+          (cond (and (zero? (.length sb))
+                     (Character/isDigit c))
+                nil
+                (or (Character/isLetterOrDigit c)
+                    (contains? allowed-punct c))
+                (.append sb (Character/toLowerCase c))
+                :else
+                (.append sb \-)))
+        (-> (.toString sb)
+            (s/replace #"-+" "-")
+            (s/replace #"^-|-$" ""))))))
 
 (defn object-schema
   [ns-prefix object-key fields]
@@ -65,14 +88,9 @@
               (letfn [(enum-datom [item]
                         (let [ns (str ns "." (name key))
                               {:keys [label value]} item]
-                          ;; TODO value may not become a keyword that can be
-                          ;; read by the clj/edn reader. That's annoying.
-                          ;; Whatever we choose to do here must be understood
-                          ;; by our readers and writers
-                          {:db/ident (keyword ns value)
-                           ;; TODO are docstrings allowed on non-attributes?
+                          {:db/ident (enum-ident ns-prefix object-key key (picklist-name value))
                            :db/doc label
-                           (keyword ns-prefix "picklist-value") value}))]
+                           (field-ident ns-prefix "picklist-value") value}))]
                 (map enum-datom (:picklistValues field))))
             (field-datoms [[key field]]
               (let [{:keys [name
@@ -85,19 +103,19 @@
                     cardinality (if (= "multipicklist" type)
                                   :db.cardinality/many
                                   :db.cardinality/one)]
-                (cons (cond-> {:db/ident (keyword ns (clojure.core/name key))
+                (cons (cond-> {:db/ident (field-attr ns-prefix object-key key)
                                :db/doc label
                                :db/valueType (get datomic-types type)
                                :db/cardinality cardinality
-                               (keyword ns-prefix "name") name
-                               (keyword ns-prefix "type") type}
+                               (field-ident ns-prefix "name") name
+                               (field-ident ns-prefix "type") type}
                         ;; Sorta funny that id types don't have :unique true
                         (or (= "id" type) unique)
                         (assoc :db/unique :db.unique/identity)
                         calculatedFormula
-                        (assoc (keyword ns-prefix "formula") calculatedFormula)
+                        (assoc (field-ident ns-prefix "formula") calculatedFormula)
                         inlineHelpText
-                        (assoc (keyword ns-prefix "helptext") inlineHelpText))
+                        (assoc (field-ident ns-prefix "helptext") inlineHelpText))
                       (when (case type
                               "picklist" true
                               "multipicklist" true
@@ -107,10 +125,11 @@
 
 (defn build-schema!
   [client ns-prefix object-keys]
-  (into (metadata-schema ns-prefix)
-        (mapcat (fn [object-key]
-                  (object-schema ns-prefix object-key (c/get-fields client object-key))))
-        object-keys))
+  [(metadata-schema ns-prefix)
+   (into []
+         (mapcat (fn [object-key]
+                   (object-schema ns-prefix object-key (c/get-fields client object-key))))
+         object-keys)])
 
 (defn assert-object!
   [client ns-prefix object-key m]
@@ -118,16 +137,17 @@
         ns (str ns-prefix "." (name object-key))
         fields (c/get-fields client object-key)]
     (reduce-kv (fn [txn field-key value]
-                 (let [attr (keyword ns (name field-key))
+                 (let [attr (field-attr ns-prefix object-key field-key)
                        field (get fields field-key)
                        {:keys [type referenceTo]} field
                        [value ref-types]
                        (case type
-                         ;; changes must be coordinated with enum-datom
                          "picklist"
-                         [(keyword (str ns "." (name field-key)) value)]
+                         (enum-ident ns-prefix object-key field-key (picklist-name value))
                          "multipicklist"
-                         [(mapv (partial keyword (str ns "." (name field-key)))
+                         [(into []
+                                (map (comp (partial enum-ident ns-prefix object-key field-key)
+                                           picklist-name))
                                 (s/split value #";"))]
                          "date"
                          [(tc/to-date value)]
@@ -144,15 +164,32 @@
                {::types #{object-key}}
                m)))
 
-;; TODO also do we want the whole schema for each type or just projections that
-;; permit out query results
 (defn assert-query!
+  "Returns a seq of transaction seqs that if transacted in order will assert
+   the results of the given query in a datomic database.
+
+   Given an ns-prefix of `ex` and a query of `{:find [:customer :id :sectors]}`
+
+   The first transaction asserts a set of attributes that will be defined on the
+   attributes that will model the salesforce fields where there is no direct
+   datomic analog, e.g. `ex.field/helptext`.
+
+   The second transaction asserts a set of attributes that model the
+   fields of objects used in the query,
+   e.g. `ex.object.customer/id`. Note this is a complete set of
+   attributes, not limited simply to those used in the query.
+
+   The last transaction asserts the entities returned by the query.
+
+   Most field values have natural datomic types. Notably, however, picklist
+   and multipicklist fields are modeled as enums whose idents are a
+   keywordized version of the picklist value with a namespace derived from
+   the object and field, e.g. `ex.object.customer.sectors/energy-efficiency`."
   [client ns-prefix query]
   (let [objects (into []
                       (comp (map (comp first seq))
                             (map (partial apply assert-object! client ns-prefix)))
                       (q/query client query))
         object-keys (reduce set/union #{} (map ::types objects))]
-    (into (build-schema! client ns-prefix object-keys)
-          (map (fn [m] (dissoc m ::types))
-               objects))))
+    (conj (build-schema! client ns-prefix object-keys)
+          (into [] (map (fn [m] (dissoc m ::types)) objects)))))

--- a/src/sails_forth/datomic.clj
+++ b/src/sails_forth/datomic.clj
@@ -117,7 +117,7 @@
                 (assoc (field-ident ns-prefix "helptext") inlineHelpText))))]
     (into [] (map field-datoms) fields)))
 
-(defn build-schema!
+(defn build-schema
   [client ns-prefix object-keys]
   [(metadata-schema ns-prefix)
    (into []
@@ -125,7 +125,7 @@
                    (object-schema ns-prefix object-key (c/get-fields client object-key))))
          object-keys)])
 
-(defn assert-object!
+(defn assert-object
   [client ns-prefix object-key m]
   (let [fields (c/get-fields client object-key)]
     (reduce-kv (fn [txn field-key value]
@@ -163,7 +163,7 @@
                {::types #{object-key}}
                m)))
 
-(defn assert-query!
+(defn assert-query
   "Returns a seq of transaction seqs that if transacted in order will assert
    the results of the given query in a datomic database.
 

--- a/src/sails_forth/datomic.clj
+++ b/src/sails_forth/datomic.clj
@@ -22,7 +22,8 @@
    "url" :db.type/uri
    "multipicklist" :db.type/string
    "phone" :db.type/string
-   "address" :db.type/ref})
+   "address" :db.type/ref
+   "email" :db.type/string})
 
 (defn field-ident
   [ns-prefix field-name]

--- a/src/sails_forth/datomic.clj
+++ b/src/sails_forth/datomic.clj
@@ -23,7 +23,8 @@
    "multipicklist" :db.type/string
    "phone" :db.type/string
    "address" :db.type/ref
-   "email" :db.type/string})
+   "email" :db.type/string
+   "encryptedstring" :db.type/string})
 
 (defn field-ident
   [ns-prefix field-name]

--- a/src/sails_forth/spec.clj
+++ b/src/sails_forth/spec.clj
@@ -65,7 +65,7 @@
 (s/def ::picklistValue
   (s/keys :req-un [
                    ; label can be nil in a picklistValue, is that correct? Awkward to express.
-                   ; ::label 
+                   ; ::label
 
                    ::value
                    ::active]))
@@ -89,7 +89,7 @@
                    ::precision
                    ::label
                    ::relationshipName]))
-(defmethod field-description-type "id" [_] 
+(defmethod field-description-type "id" [_]
   (s/keys :req-un [::type
                    ::picklistValues
                    ::name
@@ -98,7 +98,7 @@
                    ::precision
                    ::label
                    ::relationshipName]))
-(defmethod field-description-type "string" [_] 
+(defmethod field-description-type "string" [_]
   (s/keys :req-un [::type
                    ::picklistValues
                    ::name
@@ -107,7 +107,7 @@
                    ::precision
                    ::label
                    ::relationshipName]))
-(defmethod field-description-type "reference" [_] 
+(defmethod field-description-type "reference" [_]
   (s/keys :req-un [::type
                    ::picklistValues
                    ::name
@@ -116,7 +116,7 @@
                    ::precision
                    ::label
                    ::relationshipName]))
-(defmethod field-description-type "boolean" [_] 
+(defmethod field-description-type "boolean" [_]
   (s/keys :req-un [::type
                    ::picklistValues
                    ::name
@@ -125,7 +125,7 @@
                    ::precision
                    ::label
                    ::relationshipName]))
-(defmethod field-description-type "textarea" [_] 
+(defmethod field-description-type "textarea" [_]
   (s/keys :req-un [::type
                    ::picklistValues
                    ::name
@@ -134,7 +134,7 @@
                    ::precision
                    ::label
                    ::relationshipName]))
-(defmethod field-description-type "picklist" [_] 
+(defmethod field-description-type "picklist" [_]
   (s/keys :req-un [::type
                    ::picklistValues
                    ::name
@@ -143,7 +143,7 @@
                    ::precision
                    ::label
                    ::relationshipName]))
-(defmethod field-description-type "url" [_] 
+(defmethod field-description-type "url" [_]
   (s/keys :req-un [::type
                    ::picklistValues
                    ::name
@@ -152,7 +152,7 @@
                    ::precision
                    ::label
                    ::relationshipName]))
-(defmethod field-description-type "multipicklist" [_] 
+(defmethod field-description-type "multipicklist" [_]
   (s/keys :req-un [::type
                    ::picklistValues
                    ::name
@@ -161,7 +161,7 @@
                    ::precision
                    ::label
                    ::relationshipName]))
-(defmethod field-description-type "address" [_] 
+(defmethod field-description-type "address" [_]
   (s/keys :req-un [::type
                    ::picklistValues
                    ::name
@@ -170,7 +170,16 @@
                    ::precision
                    ::label
                    ::relationshipName]))
-(defmethod field-description-type "phone" [_] 
+(defmethod field-description-type "phone" [_]
+  (s/keys :req-un [::type
+                   ::picklistValues
+                   ::name
+                   ::referenceTo
+                   ::scale
+                   ::precision
+                   ::label
+                   ::relationshipName]))
+(defmethod field-description-type "email" [_]
   (s/keys :req-un [::type
                    ::picklistValues
                    ::name

--- a/src/sails_forth/spec.clj
+++ b/src/sails_forth/spec.clj
@@ -188,6 +188,15 @@
                    ::precision
                    ::label
                    ::relationshipName]))
+(defmethod field-description-type "encryptedstring" [_]
+  (s/keys :req-un [::type
+                   ::picklistValues
+                   ::name
+                   ::referenceTo
+                   ::scale
+                   ::precision
+                   ::label
+                   ::relationshipName]))
 
 (s/def ::field-description
   (s/multi-spec field-description-type :type))

--- a/test/sails_forth/datomic_test.clj
+++ b/test/sails_forth/datomic_test.clj
@@ -1,0 +1,18 @@
+(ns sails-forth.datomic-test
+  (:require [clojure.edn :as edn]
+            [clojure.test :refer :all]
+            [sails-forth.client :as sf]
+            [sails-forth.datomic :refer :all]))
+
+(deftest test-assert-query
+  (let [schema (edn/read-string (slurp "test/schema.edn"))
+        client (sf/build-memory-client schema)
+        user-id (sf/create! client "User" {"Name"  "Donald"})
+        _ (sf/create! client "Payment__c" {"Amount__c" 5
+                                           "CreatedById" user-id})
+        txns (assert-query client "sf" {:find [:payment :id
+                                               [:createdby :id :name]]})]
+    (is (= 3 (count txns)))
+    (is (= "Donald" (get-in txns [2 0
+                                  :sf.object.payment/createdby
+                                  :sf.object.user/name])))))


### PR DESCRIPTION
This provides a fn which, given a salesforce query, yields three transactions:

1. asserts a base set of metadata attributes
2. asserts a set of attributes for the fields of the objects involved in the query
3. asserts the data returned by the query

It's not entirely clear if this is a good home for this functionality, but since it's fairly tightly coupled to some somewhat subtle inner workings of sails-forth, and since it doesn't involve actually introducing datomic as a dependency, it feels fairly defensible.

One thing we might want to do is figure out how we could allow the user to choose the representation they would prefer for picklists, or in general to provide an argument for such configuration. (Picklists specifically might be more naturally represented as enums, but the incomplete nature of the salesforce api with regards to inactive picklist values makes that more troublesome and sketchy than would be ideal.)