### PR TITLE
Add take-action! implementation to memory client

### DIFF
--- a/src/sails_forth/client.clj
+++ b/src/sails_forth/client.clj
@@ -196,32 +196,36 @@
   :ret ::client)
 
 (defn build-memory-client
-  [schema]
-  (let [client (memory/create-state! schema)
-        cache (build-atomic-cache)]
-    (reify Client
-      (create! [_ type attrs]
-        (memory/create! client type attrs))
-      (delete! [_ type id]
-        (memory/delete! client type id))
-      (update! [_ type id attrs]
-        (memory/update! client type id attrs))
-      (list! [_ type]
-        (memory/list! client type))
-      (describe! [_ type]
-        (memory/describe! client type))
-      (objects! [_]
-        (memory/objects! client))
-      (query! [_ query]
-        (memory/query! client query))
-      (count! [_ query]
-        (memory/count! client query))
-      (limits! [_]
-        (memory/limits! client))
-      (import! [_ type records]
-        (future (mapv (partial create! type) records)))
-      (cache [_]
-        cache))))
+  ([schema]
+   (build-memory-client schema {}))
+  ([schema take-action-map]
+   (let [client (memory/create-state! schema)
+         cache (build-atomic-cache)]
+     (reify Client
+       (create! [_ type attrs]
+         (memory/create! client type attrs))
+       (delete! [_ type id]
+         (memory/delete! client type id))
+       (update! [_ type id attrs]
+         (memory/update! client type id attrs))
+       (list! [_ type]
+         (memory/list! client type))
+       (describe! [_ type]
+         (memory/describe! client type))
+       (objects! [_]
+         (memory/objects! client))
+       (query! [_ query]
+         (memory/query! client query))
+       (count! [_ query]
+         (memory/count! client query))
+       (limits! [_]
+         (memory/limits! client))
+       (import! [_ type records]
+         (future (mapv (partial create! type) records)))
+       (cache [_]
+         cache)
+       (take-action! [_ action inputs]
+         (memory/take-action! client take-action-map action inputs))))))
 
 (defn client?
   [x]

--- a/src/sails_forth/client.clj
+++ b/src/sails_forth/client.clj
@@ -191,8 +191,14 @@
       (take-action! [_ action inputs]
         (http/take-action! client action inputs)))))
 
+(s/def ::take-action-map
+  (s/? (s/map-of string? (s/fdef f :args (s/cat :client any?
+                                                :inputs (s/coll-of (s/map-of string? any?)))
+                                   :ret any?))))
+
 (s/fdef build-memory-client
-  :args (s/cat :schema ::memory/schema)
+  :args (s/cat :schema ::memory/schema
+               :take-action-map ::take-action-map)
   :ret ::client)
 
 (defn build-memory-client

--- a/src/sails_forth/memory.clj
+++ b/src/sails_forth/memory.clj
@@ -277,8 +277,7 @@
 
 (defn take-action!
   [astate take-action-map action inputs]
-  (let [f (get take-action-map action)]
-    (if f
-      (f astate inputs)
-      (throw (ex-info "action failed" {:cause (str f "not implemented")
-                                       :take-action-map take-action-map})))))
+  (if-let [f (get take-action-map action)]
+    (f astate inputs)
+    (throw (ex-info "action failed" {:cause (str action " not implemented")
+                                     :take-action-map take-action-map}))))

--- a/src/sails_forth/memory.clj
+++ b/src/sails_forth/memory.clj
@@ -274,3 +274,11 @@
 (defn limits!
   [astate]
   {})
+
+(defn take-action!
+  [astate take-action-map action inputs]
+  (let [f (get take-action-map action)]
+    (if f
+      (f astate inputs)
+      (throw (ex-info "action failed" {:cause (str f "not implemented")
+                                       :take-action-map take-action-map})))))

--- a/test/sails_forth/memory_test.clj
+++ b/test/sails_forth/memory_test.clj
@@ -9,7 +9,7 @@
 
 (deftest test-memory-client
   (let [schema (edn/read-string (slurp "test/schema.edn"))
-        client (sf/build-memory-client schema)]
+        client (sf/build-memory-client schema {"custom/apex/TestEndpoint" (fn [_ inputs] inputs)})]
     (testing "schema"
       (is (= #{"Payment__c" "User"}
              (set (map :name (:sobjects (sf/objects! client))))))
@@ -48,4 +48,7 @@
                [{:payment {}} ; TODO is this right? who knows
                 {:payment {:actual-date (org.joda.time.LocalDate. "2016-01-01")}}]))))
     (testing "limits"
-      (is (= {} (sf/limits! client))))))
+      (is (= {} (sf/limits! client))))
+    (testing "take-action!"
+      (is (= "some input" (sf/take-action! client "custom/apex/TestEndpoint" "some input")))
+      (is (thrown? clojure.lang.ExceptionInfo (sf/take-action! client "custom/apex/BadEndpoint" "other input"))))))

--- a/test/sails_forth/memory_test.clj
+++ b/test/sails_forth/memory_test.clj
@@ -9,7 +9,7 @@
 
 (deftest test-memory-client
   (let [schema (edn/read-string (slurp "test/schema.edn"))
-        client (sf/build-memory-client schema {"custom/apex/TestEndpoint" (fn [_ inputs] inputs)})]
+        client (sf/build-memory-client schema {"custom/apex/TestEndpoint" (fn [c inputs] inputs)})]
     (testing "schema"
       (is (= #{"Payment__c" "User"}
              (set (map :name (:sobjects (sf/objects! client))))))


### PR DESCRIPTION
The memory client can be reified with a map of action names
to functions that can be passed in when building the client.
Then take-action! can be called with an action name along
with a function that will operate on the client in memory
along with arguments passed to that function.